### PR TITLE
Fix error `Error Path must be a string. Received undefined`

### DIFF
--- a/eurlex.js
+++ b/eurlex.js
@@ -82,6 +82,9 @@ var _profile = false;
 try {
 	(function(){
 		var _check = function(p) {
+            if (arguments[0] === undefined || arguments[1] === undefined){
+                return false;
+            }
 			var _file = path.resolve.apply(this, new args(arguments).array);
 			return (fs.existsSync(_file) && fs.statSync(_file).isFile()) ? _file : false;
 		}


### PR DESCRIPTION
Fix #2 
Error is given because path to package.json is missing/undefined when -p argument is not given.
`eurlex -p package.json -vu -l de,en,fr COM:2012:0011:FIN -o eurlex-com-2012-0011-fin.json` does work. Attached code checks for undefined arguments.

